### PR TITLE
Added dependent to macros

### DIFF
--- a/lib/active_mongoid/associations/active_record/macros.rb
+++ b/lib/active_mongoid/associations/active_record/macros.rb
@@ -38,6 +38,7 @@ module ActiveMongoid
             document_getter(name, metadata)
             document_setter(name, metadata)
             autosave_documents(metadata)
+            dependent_documents(metadata)
             existence_check(name)
           end
 

--- a/lib/active_mongoid/associations/mongoid/macros.rb
+++ b/lib/active_mongoid/associations/mongoid/macros.rb
@@ -49,6 +49,7 @@ module ActiveMongoid
             record_getter(name, metadata)
             record_setter(name, metadata)
             autosave_records(metadata)
+            dependent_records(metadata)
             existence_check(name)
           end
 


### PR DESCRIPTION
Allows dependent destroy actions to work properly.
