### PR TITLE
Allow models with bsonify_attr to be saved

### DIFF
--- a/lib/active_mongoid/bson_id.rb
+++ b/lib/active_mongoid/bson_id.rb
@@ -39,7 +39,7 @@ module ActiveMongoid
         self.instance_eval do
           define_method(name) do
             attribute = read_attribute(name)
-            attribute.nil? ? nil : ::ActiveMongoid::BSON::ObjectId.from_string(attribute)
+            attribute.nil? ? nil : ::ActiveMongoid::BSON::ObjectId.from_string(attribute.to_s)
           end
         end
       end

--- a/lib/active_mongoid/version.rb
+++ b/lib/active_mongoid/version.rb
@@ -1,3 +1,3 @@
 module ActiveMongoid
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
Active Mongoid should cast attributes it expects to be strings as strings before using them. This allows models with `bsonify_attr` on any fields to be saved.
