### PR TITLE
Fix BSON module lookup for mongoid 4.0.0

### DIFF
--- a/lib/active_mongoid.rb
+++ b/lib/active_mongoid.rb
@@ -4,7 +4,7 @@ require "active_mongoid/finder_proxy"
 require "active_mongoid/finders"
 
 module ActiveMongoid
-  if ::Gem::Version.new(Mongoid::VERSION).between?(::Gem::Version.new("3.0.0"), ::Gem::Version.new("4.0.0"))
+  if ::Gem::Version.new(Mongoid::VERSION).between?(::Gem::Version.new("3.0.0"), ::Gem::Version.new("3.1.7"))
     BSON = ::Moped::BSON
   else
     BSON = ::BSON


### PR DESCRIPTION
Currently with `mongoid (4.0.0)`, I'm getting a `uninitialized constant Moped::BSON` error.
