### PR TITLE
Use #nil? method instead of comparing with nil

### DIFF
--- a/lib/active_mongoid/associations/document_relation/accessors.rb
+++ b/lib/active_mongoid/associations/document_relation/accessors.rb
@@ -22,7 +22,7 @@ module ActiveMongoid
         private
 
         def get_document_relation(name, metadata, object, reload = false)
-          if !reload && (value = instance_variable_get("@#{name}")) != nil
+          if !reload && !(value = instance_variable_get("@#{name}")).nil?
             value
           else
             if object && needs_no_database_query?(object, metadata)

--- a/lib/active_mongoid/associations/record_relation/accessors.rb
+++ b/lib/active_mongoid/associations/record_relation/accessors.rb
@@ -23,7 +23,7 @@ module ActiveMongoid
         private
 
         def get_record_relation(name, metadata, object, reload = false)
-          if !reload && (value = instance_variable_get("@#{name}")) != nil
+          if !reload && !(value = instance_variable_get("@#{name}")).nil?
             value
           else
             if object && needs_no_database_query?(object, metadata)


### PR DESCRIPTION
This suppresses the following warning message:
`/active_mongoid/associations/document_relation/accessors.rb:25: warning: Comparable#== will no more rescue exceptions of #<=> in the next release.`
