### PR TITLE
allow scopes on basic associations

### DIFF
--- a/lib/active_mongoid/associations.rb
+++ b/lib/active_mongoid/associations.rb
@@ -68,12 +68,16 @@ module ActiveMongoid
 
       private
 
-      def characterize_association(name, relation, options)
-        ActiveMongoid::Associations::Metadata.new({
+      def characterize_association(name, relation, *opts)
+        options = opts.extract_options!
+        initializer = {
           :relation => relation,
           :inverse_class_name => self.name,
           :name => name
-        }.merge(options))
+        }.merge(options)
+        initializer.merge!(scope: opts.shift) if opts.present?
+
+        ActiveMongoid::Associations::Metadata.new(initializer)
       end
 
     end

--- a/lib/active_mongoid/associations/document_relation/macros.rb
+++ b/lib/active_mongoid/associations/document_relation/macros.rb
@@ -6,18 +6,18 @@ module ActiveMongoid
 
         module ClassMethods
 
-          def belongs_to_document(name, options = {})
-            meta = characterize_association(name, Referenced::In, options)
+          def belongs_to_document(name, *opt)
+            meta = characterize_association(name, Referenced::In, *opt)
             relate_one_to_one_document(name, meta)
           end
 
-          def has_one_document(name, options = {})
-            meta = characterize_association(name, Referenced::One, options)
+          def has_one_document(name, *opt)
+            meta = characterize_association(name, Referenced::One, *opt)
             relate_one_to_one_document(name, meta)
           end
 
-          def has_many_documents(name, options = {})
-            meta = characterize_association(name, Referenced::Many, options)
+          def has_many_documents(name, *opt)
+            meta = characterize_association(name, Referenced::Many, *opt)
             relate_document(name, meta)
             # document_ids_setter(name, metadata)
             # document_ids_getter(name, metadata)

--- a/lib/active_mongoid/associations/document_relation/referenced/in.rb
+++ b/lib/active_mongoid/associations/document_relation/referenced/in.rb
@@ -60,7 +60,9 @@ module ActiveMongoid
             end
 
             def criteria(metadata, object, type = nil)
-              type.where(metadata.primary_key => object)
+              assoc = type.where(metadata.primary_key => object)
+              assoc = assoc.instance_exec(&metadata.scope) if metadata.scope?
+              assoc
             end
 
           end

--- a/lib/active_mongoid/associations/document_relation/referenced/many.rb
+++ b/lib/active_mongoid/associations/document_relation/referenced/many.rb
@@ -110,9 +110,8 @@ module ActiveMongoid
 
             def criteria(metadata, object, type = nil)
               crit = metadata.klass.where(metadata.foreign_key => object)
-              if metadata.polymorphic?
-                crit = crit.where(metadata.type => type.name)
-              end
+              crit = crit.where(metadata.type => type.name) if metadata.polymorphic?
+              crit = crit.instance_exec(&metadata.scope) if metadata.scope?
               crit
             end
 

--- a/lib/active_mongoid/associations/document_relation/referenced/one.rb
+++ b/lib/active_mongoid/associations/document_relation/referenced/one.rb
@@ -60,9 +60,8 @@ module ActiveMongoid
 
             def criteria(metadata, object, type = nil)
               crit = metadata.klass.where(metadata.foreign_key => object)
-              if metadata.polymorphic?
-                crit = crit.where(metadata.type => type.name)
-              end
+              crit = crit.where(metadata.type => type.name) if metadata.polymorphic?
+              crit = crit.instance_exec(&metadata.scope) if metadata.scope?
               crit
             end
 

--- a/lib/active_mongoid/associations/metadata.rb
+++ b/lib/active_mongoid/associations/metadata.rb
@@ -119,6 +119,14 @@ module ActiveMongoid
         @polymorphic ||= (!!self[:as] || !!self[:polymorphic])
       end
 
+      def scope
+        self[:scope]
+      end
+
+      def scope?
+        !!scope
+      end
+
       def lookup_inverses(other)
         return [ inverse_of ] if inverse_of
         if other

--- a/lib/active_mongoid/associations/record_relation/macros.rb
+++ b/lib/active_mongoid/associations/record_relation/macros.rb
@@ -6,19 +6,19 @@ module ActiveMongoid
 
         module ClassMethods
 
-          def belongs_to_record(name, options = {})
-            meta = characterize_association(name, Referenced::In, options)
+          def belongs_to_record(name, *opt)
+            meta = characterize_association(name, Referenced::In, *opt)
             reference_record(meta)
             relate_one_to_one_record(name, meta)
           end
 
-          def has_one_record(name, options = {})
-            meta = characterize_association(name, Referenced::One, options)
+          def has_one_record(name, *opt)
+            meta = characterize_association(name, Referenced::One, *opt)
             relate_one_to_one_record(name, meta)
           end
 
-          def has_many_records(name, options = {})
-            meta = characterize_association(name, Referenced::Many, options)
+          def has_many_records(name, *opt)
+            meta = characterize_association(name, Referenced::Many, *opt)
             relate_record(name, meta)
             # document_ids_setter(name, metadata)
             # document_ids_getter(name, metadata)

--- a/lib/active_mongoid/associations/record_relation/referenced/in.rb
+++ b/lib/active_mongoid/associations/record_relation/referenced/in.rb
@@ -60,7 +60,9 @@ module ActiveMongoid
             end
 
             def criteria(metadata, object, type = nil)
-              type.where(metadata.primary_key => object)
+              assoc = type.where(metadata.primary_key => object)
+              assoc = assoc.instance_exec(&metadata.scope) if metadata.scope?
+              assoc
             end
 
           end

--- a/lib/active_mongoid/associations/record_relation/referenced/many.rb
+++ b/lib/active_mongoid/associations/record_relation/referenced/many.rb
@@ -114,9 +114,8 @@ module ActiveMongoid
 
             def criteria(metadata, object, type = nil)
               crit = metadata.klass.where(metadata.foreign_key => object.to_s)
-              if metadata.polymorphic?
-                crit = crit.where(metadata.type => type.name)
-              end
+              crit = crit.where(metadata.type => type.name) if metadata.polymorphic?
+              crit = crit.instance_exec(&metadata.scope) if metadata.scope?
               crit
             end
 

--- a/lib/active_mongoid/associations/record_relation/referenced/one.rb
+++ b/lib/active_mongoid/associations/record_relation/referenced/one.rb
@@ -60,9 +60,8 @@ module ActiveMongoid
 
             def criteria(metadata, object, type = nil)
               crit = metadata.klass.where(metadata.foreign_key => object)
-              if metadata.polymorphic?
-                crit = crit.where(metadata.type => type.name)
-              end
+              crit = crit.where(metadata.type => type.name) if metadata.polymorphic?
+              crit = crit.instance_exec(&metadata.scope) if metadata.scope?
               crit
             end
 


### PR DESCRIPTION
Parallels Rails 4 scoped associations. E.g., has_one :special_thing, class_name "Thing", ->{where special: true}.

However I'm not solid on creating & running spec / tests, so I'd love to collaborate on that part.
