### PR TITLE
NoMethodError: private method `existence_check' called for 

### DIFF
--- a/active_mongoid.gemspec
+++ b/active_mongoid.gemspec
@@ -18,15 +18,15 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport"
-  spec.add_dependency "activerecord"
-  spec.add_dependency "bson_ext"
-  spec.add_dependency "mongoid", '>= 5.0.0'
-  spec.add_dependency "after_do"
+  spec.add_dependency "activesupport", "> 3.2.0"
+  spec.add_dependency "activerecord", "> 3.2.0"
+  spec.add_dependency "bson_ext", "> 1.5.0"
+  spec.add_dependency "mongoid", "> 2.8.0"
+  spec.add_dependency "after_do", "~> 0.3.0"
 
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "sqlite3"
-  spec.add_development_dependency "database_cleaner", "~> 1.5.2"
+  spec.add_development_dependency "rspec", "> 3.1.0"
+  spec.add_development_dependency "sqlite3", "> 1.3.10"
+  spec.add_development_dependency "database_cleaner", "> 1.3.0"
   spec.add_development_dependency "pry", "~> 0.10.1"
   spec.add_development_dependency "simplecov", "~> 0.8.0"
   spec.add_development_dependency "simplecov-gem-adapter", "~> 1.0.0"

--- a/active_mongoid.gemspec
+++ b/active_mongoid.gemspec
@@ -18,15 +18,15 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", "> 3.2.0"
-  spec.add_dependency "activerecord", "> 3.2.0"
-  spec.add_dependency "bson_ext", "> 1.5.0"
-  spec.add_dependency "mongoid", "> 2.8.0"
-  spec.add_dependency "after_do", "~> 0.3.0"
+  spec.add_dependency "activesupport"
+  spec.add_dependency "activerecord"
+  spec.add_dependency "bson_ext"
+  spec.add_dependency "mongoid", '>= 5.0.0'
+  spec.add_dependency "after_do"
 
-  spec.add_development_dependency "rspec", "~> 3.1.0"
-  spec.add_development_dependency "sqlite3", "~> 1.3.10"
-  spec.add_development_dependency "database_cleaner", "~> 1.3.0"
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "database_cleaner", "~> 1.5.2"
   spec.add_development_dependency "pry", "~> 0.10.1"
   spec.add_development_dependency "simplecov", "~> 0.8.0"
   spec.add_development_dependency "simplecov-gem-adapter", "~> 1.0.0"

--- a/lib/active_mongoid/associations/document_relation/accessors.rb
+++ b/lib/active_mongoid/associations/document_relation/accessors.rb
@@ -40,8 +40,6 @@ module ActiveMongoid
 
         module ClassMethods
 
-          private
-
           def existence_check(name)
             module_eval <<-END
               def #{name}?
@@ -52,6 +50,7 @@ module ActiveMongoid
             self
           end
 
+          private
           # Getters
 
           def document_getter(name, metadata)

--- a/lib/active_mongoid/associations/document_relation/referenced/many.rb
+++ b/lib/active_mongoid/associations/document_relation/referenced/many.rb
@@ -21,7 +21,7 @@ module ActiveMongoid
 
           def persist_delayed(docs, inserts)
             unless docs.empty?
-              collection.insert(inserts)
+              collection.insert_many(inserts)
               docs.each do |doc|
                 doc.new_record = false
               end

--- a/lib/active_mongoid/associations/record_relation/accessors.rb
+++ b/lib/active_mongoid/associations/record_relation/accessors.rb
@@ -41,8 +41,6 @@ module ActiveMongoid
 
         module ClassMethods
 
-          private
-
           def existence_check(name)
             module_eval <<-END
               def #{name}?
@@ -52,6 +50,8 @@ module ActiveMongoid
             END
             self
           end
+
+          private
 
           def record_getter(name, metadata)
             self.instance_eval do

--- a/lib/active_mongoid/version.rb
+++ b/lib/active_mongoid/version.rb
@@ -1,3 +1,3 @@
 module ActiveMongoid
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,9 @@ require 'rspec'
 
 Mongoid.configure do |config|
   version = ::Gem::Version.new(Mongoid::VERSION)
-  if version >= ::Gem::Version.new("3.0.0")
+  if version >= ::Gem::Version.new("4.0.0")
+    config.connect_to('active_mongoid_test')
+  elsif version >= ::Gem::Version.new("3.0.0")
     config.sessions = {
       default: {
         database: 'active_mongoid_test',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,7 @@ require 'rspec'
 
 Mongoid.configure do |config|
   version = ::Gem::Version.new(Mongoid::VERSION)
-  if version >= ::Gem::Version.new("4.0.0")
+  if version >= ::Gem::Version.new("5.0.0")
     config.connect_to('active_mongoid_test')
   elsif version >= ::Gem::Version.new("3.0.0")
     config.sessions = {


### PR DESCRIPTION
Because the method check_existance is no longer a private method in mongoid, I have to moved this relation in order to have relations by mongoid with other non-relational classes.
for example:
has_one_document :team 
has_one :player
This is now impossible to perform