### PR TITLE
record_relation existence_check method signature

### DIFF
--- a/lib/active_mongoid/associations/document_relation/accessors.rb
+++ b/lib/active_mongoid/associations/document_relation/accessors.rb
@@ -40,8 +40,6 @@ module ActiveMongoid
 
         module ClassMethods
 
-          private
-
           def existence_check(name)
             module_eval <<-END
               def #{name}?
@@ -52,6 +50,7 @@ module ActiveMongoid
             self
           end
 
+          private
           # Getters
 
           def document_getter(name, metadata)

--- a/lib/active_mongoid/associations/record_relation/accessors.rb
+++ b/lib/active_mongoid/associations/record_relation/accessors.rb
@@ -41,8 +41,6 @@ module ActiveMongoid
 
         module ClassMethods
 
-          private
-
           def existence_check(name)
             module_eval <<-END
               def #{name}?
@@ -52,6 +50,8 @@ module ActiveMongoid
             END
             self
           end
+
+          private
 
           def record_getter(name, metadata)
             self.instance_eval do

--- a/lib/active_mongoid/associations/record_relation/accessors.rb
+++ b/lib/active_mongoid/associations/record_relation/accessors.rb
@@ -41,7 +41,7 @@ module ActiveMongoid
 
         module ClassMethods
 
-          def existence_check(name)
+          def existence_check(name, relations_metadata=nil)
             module_eval <<-END
               def #{name}?
                 !__send__(:#{name}).blank?

--- a/lib/active_mongoid/version.rb
+++ b/lib/active_mongoid/version.rb
@@ -1,3 +1,3 @@
 module ActiveMongoid
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
After incorporating iranedo's pull request
I still had the following error:
wrong number of arguments (2 for 1)

This came from record_relation/accessors.rb's existance_check
The second argument is not used but needs to be present to avoid the error.

class User
  include Mongoid::Document
  include ActiveMongoid::Associations
  ..snip..
  has_one_record :banana # active_record model
end

class Banana < ActiveRecord::Base
  include ActiveMongoid::Associations
  belongs_to_document :user

end
