### PR TITLE
Prevent :autosave_record_id from Overwriting Changes

### DIFF
--- a/lib/active_mongoid/associations/record_relation/auto_save.rb
+++ b/lib/active_mongoid/associations/record_relation/auto_save.rb
@@ -27,6 +27,7 @@ module ActiveMongoid
             if metadata.stores_foreign_key?
               save_method = :"autosave_record_id_for_#{metadata.name}"
               define_method(save_method) do
+                return if self.changed.include?(metadata.foreign_key)
                 if relation = instance_variable_get("@#{metadata.name}")
                   self.send(metadata.foreign_key_setter, relation.send(metadata.primary_key))
                 end


### PR DESCRIPTION
When saving a document that `has_one_record`, the foreign key of a relation is always overwritten by the primary key of relation when it is cached. We need to either purge the instance variable that the relation is stored in when foreign_key is reset or avoid automatically updating the relation when foreign_key attribute has been changed.